### PR TITLE
Merge BNL Hackathon 2020 NVTX and prefetch work into Summit branch

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -218,6 +218,11 @@ class EceiDataset(data.Dataset):
     def read_data(self,index):
         shot_index = self.shot_idxi[index]
         filename = self.create_filename(shot_index)
+
+        ###TEST! TEST! TEST! just for profiling, remove!!!!!!!!!!!!
+        #X = np.random.rand(20,8,int((self.stop_idxi[index]-self.start_idxi[index])/self.data_step)).astype('float32')
+        #return X
+
         f = h5py.File(filename,'r')
         #check if weve read in offsets yet
         if np.all(self.offsets[...,shot_index]==0):

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ parser.add_argument('--plot', action='store_true',
 
 
 
-root = '/gpfs/wolf/proj-shared/gen141/disruptCNN/ecei_d3d/'
+root =  '/gpfs/alpine/proj-shared/fus131/ecei_d3d/'
 data_root = root+'data/'
 clear_file = root + 'd3d_clear_ecei.final.txt'
 disrupt_file = root + 'd3d_disrupt_ecei.final.txt'

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ parser.add_argument('--plot', action='store_true',
 
 
 
-root =  '/gpfs/alpine/proj-shared/fus131/ecei_d3d/'
+root = '/gpfs/alpine/proj-shared/fus131/ecei_d3d/'
 data_root = root+'data/'
 clear_file = root + 'd3d_clear_ecei.final.txt'
 disrupt_file = root + 'd3d_disrupt_ecei.final.txt'

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#BSUB -P fus131
+#BSUB -P gen141
 #BSUB -J test_disrupt
 #BSUB -W 00:30 #30 minutes
-#BSUB -q debug
+##BSUB -q debug
 #BSUB -nnodes 1
 
 #echo this run.sh file contents in the log file, to capture inputs
@@ -28,19 +28,21 @@ echo "git commit"
 git --git-dir=$PWD/disruptcnn/.git  show --oneline -s
 
 #for cProfile, to force sync CUDA ops
-export CUDA_LAUNCH_BLOCKING=0
+#export CUDA_LAUNCH_BLOCKING=0
 
-file="file:///gpfs/alpine/scratch/rchurchi/fus131/main_${LSB_JOBID}.txt"
+export OMP_NUM_THREADS=6
+
+file="file:///gpfs/wolf/gen141/scratch/rchurchi/main_${LSB_JOBID}.txt"
 #fileprof="profile_${LSB_JOBID}_rank_${LS_JOBPID}.prof"
-source activate torch-env
+#source activate torch-env
 jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 --gpu_per_rs 1 \
-		   python -u disruptcnn/main.py --dist-url $file --backend 'nccl' \
+		   python -u -m torch.utils.bottleneck disruptcnn/main.py --dist-url $file --backend 'nccl' \
                     --batch-size=12 --dropout=0.1 --clip=0.3 \
                     --lr=0.5 \
                     --workers=6 \
                     --nsub 78125 \
-                    --epochs=1500 \
+                    --epochs=2 \
                     --label-balance='const' \
                     --data-step=10 --levels=4 --nrecept=30000 --nhid=80 \
                     --undersample \
-                    --iterations-valid 60
+                    --iterations-valid 600

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#BSUB -P gen141
+#BSUB -P fus131
 #BSUB -J test_disrupt
-#BSUB -W 01:00 #30 minutes
-##BSUB -q debug
+#BSUB -W 00:30 #30 minutes
+#BSUB -q debug
 #BSUB -nnodes 1
 #BSUB -alloc_flags maximizegpfs
 
@@ -31,18 +31,17 @@ git --git-dir=$PWD/disruptcnn/.git  show --oneline -s
 #for cProfile, to force sync CUDA ops
 #export CUDA_LAUNCH_BLOCKING=0
 
+file="file:///gpfs/alpine/scratch/rchurchi/fus131/main_${LSB_JOBID}.txt"
 export OMP_NUM_THREADS=8
-
-file="file:///gpfs/wolf/gen141/scratch/rchurchi/main_${LSB_JOBID}.txt"
 #fileprof="profile_${LSB_JOBID}_rank_${LS_JOBPID}.prof"
-#source activate torch-env
 module load ibm-wml-ce
-conda activate /gpfs/wolf/gen141/proj-shared/disruptCNN/conda-envs/torch-env
+source activate torch-env
 module load nsight-systems
-jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 -b packed:6 --gpu_per_rs 1 \
+#may have to specify full path to python here (on Ascent had to with nsys)
+jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 --gpu_per_rs 1 \
                    nsys profile -t cuda,nvtx -s cpu -o profile_%q{OMPI_COMM_WORLD_RANK} \
-		   /gpfs/wolf/gen141/proj-shared/disruptCNN/conda-envs/torch-env/bin/python -u disruptcnn/main.py --dist-url $file --backend 'nccl' \
-                    --batch-size=2 --dropout=0.1 --clip=0.3 \
+		   python -u disruptcnn/main.py --dist-url $file --backend 'nccl' \
+                    --batch-size=12 --dropout=0.1 --clip=0.3 \
                     --lr=0.5 \
                     --workers=6 \
                     --nsub 78125 \
@@ -50,8 +49,6 @@ jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 -b packed:6 --gpu_
                     --label-balance='const' \
                     --data-step=10 --levels=4 --nrecept=30000 --nhid=80 \
                     --undersample \
-                    --iterations-valid 600 \
-        		    --test-indices 0 1 2 3 4 5
-
+                    --iterations-valid 600
 #try to ensure the profiler and file movement finishes with everything
 sleep 60

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #BSUB -P gen141
 #BSUB -J test_disrupt
-#BSUB -W 00:30 #30 minutes
+#BSUB -W 01:00 #30 minutes
 ##BSUB -q debug
 #BSUB -nnodes 1
+#BSUB -alloc_flags maximizegpfs
 
 #echo this run.sh file contents in the log file, to capture inputs
 echo "$0"
@@ -30,19 +31,27 @@ git --git-dir=$PWD/disruptcnn/.git  show --oneline -s
 #for cProfile, to force sync CUDA ops
 #export CUDA_LAUNCH_BLOCKING=0
 
-export OMP_NUM_THREADS=6
+export OMP_NUM_THREADS=8
 
 file="file:///gpfs/wolf/gen141/scratch/rchurchi/main_${LSB_JOBID}.txt"
 #fileprof="profile_${LSB_JOBID}_rank_${LS_JOBPID}.prof"
 #source activate torch-env
-jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 --gpu_per_rs 1 \
-		   python -u -m torch.utils.bottleneck disruptcnn/main.py --dist-url $file --backend 'nccl' \
-                    --batch-size=12 --dropout=0.1 --clip=0.3 \
+module load ibm-wml-ce
+conda activate /gpfs/wolf/gen141/proj-shared/disruptCNN/conda-envs/torch-env
+module load nsight-systems
+jsrun --nrs 6 --rs_per_host 6 --tasks_per_rs 1 --cpu_per_rs 6 -b packed:6 --gpu_per_rs 1 \
+                   nsys profile -t cuda,nvtx -s cpu -o profile_%q{OMPI_COMM_WORLD_RANK} \
+		   /gpfs/wolf/gen141/proj-shared/disruptCNN/conda-envs/torch-env/bin/python -u disruptcnn/main.py --dist-url $file --backend 'nccl' \
+                    --batch-size=2 --dropout=0.1 --clip=0.3 \
                     --lr=0.5 \
                     --workers=6 \
                     --nsub 78125 \
-                    --epochs=2 \
+                    --epochs=4 \
                     --label-balance='const' \
                     --data-step=10 --levels=4 --nrecept=30000 --nhid=80 \
                     --undersample \
-                    --iterations-valid 600
+                    --iterations-valid 600 \
+        		    --test-indices 0 1 2 3 4 5
+
+#try to ensure the profiler and file movement finishes with everything
+sleep 60


### PR DESCRIPTION
Various changes to do prefetching (really interleaving of loading with CUDA streams), and nvtx markers for profiling. Also there is the option now for a `itertools.cycle` on the loader, which caches the data in memory (but currently doesn't allow shuffling, which stagnates the learning, but this could be modified). The issue this cycle() solves is that the data workers are recreated each epoch, which give a minimum data loading time at the beginning of each epoch, instead of having the end of the last epoch have the workers load the data for the next epoch.